### PR TITLE
add dist file to files so it's preserved

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules",
     "prepare": "npm run build"
   },
+  "files": [
+      "dist/vuetagger.js"
+  ],
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",


### PR DESCRIPTION
Sorry I forgot to do this in my original PR - this makes sure that, despite being in the .gitignore, dist/vuetagger.js is used by NPM.